### PR TITLE
Update Haskell nlpwp link to point to github

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ A curated list of anything remotely related to linguistics, sorted in alphabetic
 *Some of the more interesting and complete books.*
 
 #### Free
-* [Natural Language Processing for the Working Programmer](http://nlpwp.org/book/index.xhtml) - Unmaintained resource using the haskell programming language
+* [Natural Language Processing for the Working Programmer](https://github.com/nlpwp) - Unmaintained resource using the haskell programming language
 * [Natural Language Processing with Python](http://www.nltk.org/book/) - The book from the NLTK package
 
 #### Non free


### PR DESCRIPTION
The nlpwp.org site has been gone for a long time, but the resources are on github
so it's probably better to link to them.