### PR TITLE
Adding Language Science Press 

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ A curated list of anything remotely related to linguistics, sorted in alphabetic
 * [Introduction to Linguistics](https://linguistics.ucla.edu/people/Kracht/courses/ling20-fall07/ling-intro.pdf)
 * [Natural Language Processing with Python](http://www.nltk.org/book/) - The book from the NLTK package.
 * [Text Mining with R](https://www.tidytextmining.com)
+* [Language Science Press](https://langsci-press.org/) - Language Science Press is a born-digital scholar-led open access publisher in linguistics.
 
 #### Non free
 * [Foundations of Computational Linguistics](http://books.google.com/books?id=o9iGAgAAQBAJ&dq=Foundations+of+Computational+Linguistics&hl=nl&source=gbs_navlinks_s)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ A curated list of anything remotely related to linguistics, sorted in alphabetic
 ### Resources
 * [How To Label Data](https://www.lighttag.io/how-to-label-data/) - Guide on managing large scale linguistic annotation projects.
 * [Low Resource Languages](https://github.com/RIchardLitt/low-resource-languages) - A list of resources for conservation, development, and documentation of low resource (human) languages.
+* [Language Science Press](https://langsci-press.org/) - Language Science Press is a born-digital scholar-led open access publisher in linguistics.
+
 
 ### On Wikipedia
 * [Bag of words model](http://en.wikipedia.org/wiki/Bag-of-words_model)
@@ -61,7 +63,6 @@ A curated list of anything remotely related to linguistics, sorted in alphabetic
 * [Introduction to Linguistics](https://linguistics.ucla.edu/people/Kracht/courses/ling20-fall07/ling-intro.pdf)
 * [Natural Language Processing with Python](http://www.nltk.org/book/) - The book from the NLTK package.
 * [Text Mining with R](https://www.tidytextmining.com)
-* [Language Science Press](https://langsci-press.org/) - Language Science Press is a born-digital scholar-led open access publisher in linguistics.
 
 #### Non free
 * [Foundations of Computational Linguistics](http://books.google.com/books?id=o9iGAgAAQBAJ&dq=Foundations+of+Computational+Linguistics&hl=nl&source=gbs_navlinks_s)


### PR DESCRIPTION
Language Science Press is a independent publisher for researchers in Linguistics. They currently 176 finished works available as PDFs plus several others W.I.P.