### PR TITLE
Add a utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ A curated list of anything remotely related to linguistics, sorted in alphabetic
 * [Mate Tools](http://hdl.handle.net/11022/1007-0000-0000-8E4E-A), webservice via WebLicht
 * [UBIAI](https://ubiai.tools/) - Easy-to-use text annotation tool for teams with most comprehensive auto-annotation features. Supports NER, relations and document classification as well as OCR annotation for invoice labeling.
 * [textblob-de](https://github.com/markuskiller/textblob-de) - Nice alternative for spacy (see above).
+* [tyo](https://github.com/mongsvo/tyo) - A utility for finding Typo-Bridges.
 * [UralicNLP](https://github.com/mikahama/uralicNLP) - An open source Python library for processing morphologically rich and, for the most part, endangered Uralic languages. It can do morphological analysis, generation, lemmatization, disambiguation and lexical lookup for a great many Uralic languages.
 
 ### Algorithms


### PR DESCRIPTION
A small utility written in Rust (optionally using FAISS) for finding Typo Bridges. A bit more artistic than scientific perhaps, but definitely related to linguistics :)